### PR TITLE
[DHPA] Validate the host port/host port range found by ECS Agent before returning it

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -630,6 +630,7 @@ func (cfg *Config) String() string {
 			"DependentContainersPullUpfront: %v, "+
 			"TaskCPUMemLimit: %v, "+
 			"ShouldExcludeIPv6PortBinding: %v, "+
+			"DynamicHostPortRange: %v"+
 			"%s",
 		cfg.Cluster,
 		cfg.AWSRegion,
@@ -648,6 +649,7 @@ func (cfg *Config) String() string {
 		cfg.DependentContainersPullUpfront,
 		cfg.TaskCPUMemLimit,
 		cfg.ShouldExcludeIPv6PortBinding,
+		cfg.DynamicHostPortRange,
 		cfg.platformString(),
 	)
 }

--- a/agent/utils/ephemeral_ports.go
+++ b/agent/utils/ephemeral_ports.go
@@ -34,6 +34,8 @@ const (
 	portUnavailableMsg       = "Port %v is unavailable or an error occurred while listening on the local %v network"
 	portNotFoundErrMsg       = "a host port is unavailable"
 	portsNotFoundErrMsg      = "%v contiguous host ports are unavailable"
+	portRangeErrMsg          = "The host port range: %s found by ECS Agent is not within the expected host port range: %s"
+	portErrMsg               = "The host port: %s found by ECS Agent is not within the expected host port range: %s"
 )
 
 var (
@@ -108,6 +110,13 @@ func GetHostPortRange(numberOfPorts int, protocol string, dynamicHostPortRange s
 	portLock.Lock()
 	defer portLock.Unlock()
 	result, err := getNumOfHostPorts(numberOfPorts, protocol, dynamicHostPortRange)
+	if err == nil {
+		// Verify the found host port range is within the given dynamic host port range
+		if isInRange := verifyPortsWithinRange(result, dynamicHostPortRange); !isInRange {
+			errMsg := fmt.Errorf(portRangeErrMsg, result, dynamicHostPortRange)
+			return "", errMsg
+		}
+	}
 	return result, err
 }
 
@@ -119,10 +128,15 @@ func GetHostPort(protocol string, dynamicHostPortRange string) (string, error) {
 	defer portLock.Unlock()
 	numberOfPorts := 1
 	result, err := getNumOfHostPorts(numberOfPorts, protocol, dynamicHostPortRange)
+	foundHostPort := strings.Split(result, "-")[0]
 	if err == nil {
-		result = strings.Split(result, "-")[0]
+		// Verify the found host port is within the given dynamic host port range
+		if isInRange := verifyPortsWithinRange(result, dynamicHostPortRange); !isInRange {
+			errMsg := fmt.Errorf(portErrMsg, foundHostPort, dynamicHostPortRange)
+			return "", errMsg
+		}
 	}
-	return result, err
+	return foundHostPort, err
 }
 
 // getNumOfHostPorts returns the requested number of host ports using the given dynamic host port range
@@ -220,9 +234,9 @@ func getHostPortRange(numberOfPorts, start, end int, protocol string) (string, i
 	return fmt.Sprintf("%d-%d", resultStartPort, resultEndPort), resultEndPort, nil
 }
 
-// PortIsInRange returns true if the given port is within the start-end port range;
+// portIsInRange returns true if the given port is within the start-end port range;
 // otherwise, returns false.
-func PortIsInRange(port, start, end int) bool {
+func portIsInRange(port, start, end int) bool {
 	if (port >= start) && (port <= end) {
 		return true
 	}
@@ -231,15 +245,15 @@ func PortIsInRange(port, start, end int) bool {
 
 // VerifyPortsWithinRange returns true if the actualPortRange is within the expectedPortRange;
 // otherwise, returns false.
-func VerifyPortsWithinRange(actualPortRange, expectedPortRange string) bool {
+func verifyPortsWithinRange(actualPortRange, expectedPortRange string) bool {
 	// Get the actual start port and end port
 	aStartPort, aEndPort, _ := nat.ParsePortRangeToInt(actualPortRange)
 	// Get the expected start port and end port
 	eStartPort, eEndPort, _ := nat.ParsePortRangeToInt(expectedPortRange)
 	// Check the actual start port is in the expected range or not
-	aStartIsInRange := PortIsInRange(aStartPort, eStartPort, eEndPort)
+	aStartIsInRange := portIsInRange(aStartPort, eStartPort, eEndPort)
 	// Check the actual end port is in the expected range or not
-	aEndIsInRange := PortIsInRange(aEndPort, eStartPort, eEndPort)
+	aEndIsInRange := portIsInRange(aEndPort, eStartPort, eEndPort)
 
 	// Return true if both actual start port and end port are in the expected range
 	if aStartIsInRange && aEndIsInRange {

--- a/agent/utils/ephemeral_ports.go
+++ b/agent/utils/ephemeral_ports.go
@@ -214,3 +214,32 @@ func getHostPortRange(numberOfPorts, start, end int, protocol string) (string, i
 
 	return fmt.Sprintf("%d-%d", resultStartPort, resultEndPort), resultEndPort, nil
 }
+
+// PortIsInRange returns true if the given port is within the start-end port range;
+// otherwise, returns false.
+func PortIsInRange(port, start, end int) bool {
+	if (port >= start) && (port <= end) {
+		return true
+	}
+	return false
+}
+
+// VerifyPortsWithinRange returns true if the actualPortRange is within the expectedPortRange;
+// otherwise, returns false.
+func VerifyPortsWithinRange(actualPortRange, expectedPortRange string) bool {
+	// Get the actual start port and end port
+	aStartPort, aEndPort, _ := nat.ParsePortRangeToInt(actualPortRange)
+	// Get the expected start port and end port
+	eStartPort, eEndPort, _ := nat.ParsePortRangeToInt(expectedPortRange)
+	// Check the actual start port is in the expected range or not
+	aStartIsInRange := PortIsInRange(aStartPort, eStartPort, eEndPort)
+	// Check the actual end port is in the expected range or not
+	aEndIsInRange := PortIsInRange(aEndPort, eStartPort, eEndPort)
+
+	// Return true if both actual start port and end port are in the expected range
+	if aStartIsInRange && aEndIsInRange {
+		return true
+	}
+
+	return false
+}

--- a/agent/utils/ephemeral_ports.go
+++ b/agent/utils/ephemeral_ports.go
@@ -96,6 +96,11 @@ func (pt *safePortTracker) GetLastAssignedHostPort() int {
 
 var tracker safePortTracker
 
+// ResetTracker resets the last assigned host port to 0.
+func ResetTracker() {
+	tracker.SetLastAssignedHostPort(0)
+}
+
 // GetHostPortRange gets N contiguous host ports from the ephemeral host port range defined on the host.
 // dynamicHostPortRange can be set by customers using ECS Agent environment variable ECS_DYNAMIC_HOST_PORT_RANGE;
 // otherwise, ECS Agent will use the default value returned from GetDynamicHostPortRange() in the utils package.

--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -144,7 +144,7 @@ func TestGetHostPortRange(t *testing.T) {
 					assert.Equal(t, tc.expectedLastAssignedPort[i], actualLastAssignedHostPort)
 				} else {
 					// need to reset the tracker to avoid getting data from previous test cases
-					tracker.SetLastAssignedHostPort(0)
+					ResetTracker()
 
 					hostPortRange, err := GetHostPortRange(tc.numberOfPorts, tc.protocol, tc.testDynamicHostPortRange)
 					assert.Equal(t, tc.expectedError, err)
@@ -196,7 +196,8 @@ func TestGetHostPort(t *testing.T) {
 
 	for _, tc := range testCases {
 		if tc.resetLastAssignedHostPort {
-			tracker.SetLastAssignedHostPort(0)
+			// need to reset the tracker to avoid getting data from previous test cases
+			ResetTracker()
 		}
 
 		t.Run(tc.testName, func(t *testing.T) {
@@ -273,6 +274,14 @@ func TestVerifyPortsWithinRange(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, result)
 		})
 	}
+}
+
+func TestResetTracker(t *testing.T) {
+	tracker.SetLastAssignedHostPort(100)
+	ResetTracker()
+	expectedResetVal := 0
+	actualResult := tracker.GetLastAssignedHostPort()
+	assert.Equal(t, expectedResetVal, actualResult)
 }
 
 func getPortRangeLength(portRange string) (int, error) {

--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -207,9 +207,70 @@ func TestGetHostPort(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, numberOfPorts, numberOfHostPorts)
 
-				actualResult := verifyPortsWithinRange(hostPortRange, tc.testDynamicHostPortRange)
+				actualResult := VerifyPortsWithinRange(hostPortRange, tc.testDynamicHostPortRange)
 				assert.True(t, actualResult)
 			}
+		})
+	}
+}
+
+func TestPortIsInRange(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		testPort       int
+		testStartPort  int
+		testEndPort    int
+		expectedResult bool
+	}{
+		{
+			testName:       "in the range",
+			testPort:       100,
+			testStartPort:  1,
+			testEndPort:    9999,
+			expectedResult: true,
+		},
+		{
+			testName:       "not in the range",
+			testPort:       10000,
+			testStartPort:  1,
+			testEndPort:    9999,
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := PortIsInRange(tc.testPort, tc.testStartPort, tc.testEndPort)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestVerifyPortsWithinRange(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		testActualRange   string
+		testExpectedRange string
+		expectedResult    bool
+	}{
+		{
+			testName:          "in the expected range",
+			testActualRange:   "1000-1005",
+			testExpectedRange: "900-2000",
+			expectedResult:    true,
+		},
+		{
+			testName:          "not in the expected range",
+			testActualRange:   "1-2",
+			testExpectedRange: "2-100",
+			expectedResult:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := VerifyPortsWithinRange(tc.testActualRange, tc.testExpectedRange)
+			assert.Equal(t, tc.expectedResult, result)
 		})
 	}
 }
@@ -220,32 +281,4 @@ func getPortRangeLength(portRange string) (int, error) {
 		return 0, err
 	}
 	return endPort - startPort + 1, nil
-}
-
-// verifyPortsWithinRange returns true if the actualPortRange is within the expectedPortRange;
-// otherwise, returns false.
-func verifyPortsWithinRange(actualPortRange, expectedPortRange string) bool {
-	// get the actual start port and end port
-	aStartPort, aEndPort, _ := nat.ParsePortRangeToInt(actualPortRange)
-	// get the expected start port and end port
-	eStartPort, eEndPort, _ := nat.ParsePortRangeToInt(expectedPortRange)
-	// check the actual start port is in the expected range or not
-	aStartIsInRange := portIsInRange(aStartPort, eStartPort, eEndPort)
-	// check the actual end port is in the expected range or not
-	aEndIsInRange := portIsInRange(aEndPort, eStartPort, eEndPort)
-
-	// return true if both actual start port and end port are in the expected range
-	if aStartIsInRange && aEndIsInRange {
-		return true
-	}
-
-	return false
-}
-
-// portIsInRange checks the given port is within the start-end range
-func portIsInRange(port, start, end int) bool {
-	if (port >= start) && (port <= end) {
-		return true
-	}
-	return false
 }

--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -207,9 +207,6 @@ func TestGetHostPort(t *testing.T) {
 				numberOfHostPorts, err := getPortRangeLength(hostPortRange)
 				assert.NoError(t, err)
 				assert.Equal(t, numberOfPorts, numberOfHostPorts)
-
-				actualResult := VerifyPortsWithinRange(hostPortRange, tc.testDynamicHostPortRange)
-				assert.True(t, actualResult)
 			}
 		})
 	}
@@ -241,7 +238,7 @@ func TestPortIsInRange(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			result := PortIsInRange(tc.testPort, tc.testStartPort, tc.testEndPort)
+			result := portIsInRange(tc.testPort, tc.testStartPort, tc.testEndPort)
 			assert.Equal(t, tc.expectedResult, result)
 		})
 	}
@@ -270,7 +267,7 @@ func TestVerifyPortsWithinRange(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			result := VerifyPortsWithinRange(tc.testActualRange, tc.testExpectedRange)
+			result := verifyPortsWithinRange(tc.testActualRange, tc.testExpectedRange)
 			assert.Equal(t, tc.expectedResult, result)
 		})
 	}


### PR DESCRIPTION
### Summary
DHPA - Dynamic Host Port Assignment

__The target branch of this PR is [feature/dynamicHostPortAssignment](https://github.com/aws/amazon-ecs-agent/tree/feature/dynamicHostPortAssignment)__.

This is a follow-up PR for [Upudate dockerPortMap() in task.go with dynamic host port range support - part 1](https://github.com/aws/amazon-ecs-agent/pull/3584) to validate the host port/host port range found by ECS Agent before returning it through `GetHostPort()`/`GetHostPortRange()`.

### Implementation details
__agent/utils/ephemeral_ports.go__
* Add host port/host port range validation to `GetHostPort()`/`GetHostPortRange()`
* Make `portIsInRange()` and `verifyPortsWithinRange()` to private function 

__agent/utils/ephemeral_ports_test.go__
* Remove host port validation in `TestGetHostPort` as the port should be validated before returning back from  `utils.GetHostPort()`

__agent/api/task/task.go__
* Update comments
* Remove unclear `logger.Debug` entry from `dockerPortMap()`

__agent/api/task/task_test.go__
* Remove singular host port and host port range validation in `TestDockerHostConfigPortBinding` and `TestDockerHostConfigSCBridgeMode` as ports should be validated before returning back from  `utils.GetHostPort()`/`utils.GetHostPortRange()`

### Testing
#### Unit test
Re-ran the existing unit tests.
```
-- PASS: TestGetHostPortRange (0.00s)
    --- PASS: TestGetHostPortRange/tcp_protocol,_contiguous_hostPortRange_found (0.00s)
    --- PASS: TestGetHostPortRange/udp_protocol,_contiguous_hostPortRange_found (0.00s)
    --- PASS: TestGetHostPortRange/2_requests_for_contiguous_hostPortRange_in_succession,_success (0.00s)
    --- PASS: TestGetHostPortRange/contiguous_hostPortRange_after_looping_back,_success (0.00s)
    --- PASS: TestGetHostPortRange/contiguous_hostPortRange_not_found (0.00s)
```

```
--- PASS: TestGetHostPort (0.00s)
    --- PASS: TestGetHostPort/tcp_protocol,_a_host_port_found (0.00s)
    --- PASS: TestGetHostPort/udp_protocol,_a_host_port_found (0.00s)
    --- PASS: TestGetHostPort/5_requests_for_host_port_in_succession,_success (0.00s)
    --- PASS: TestGetHostPort/5_requests_for_host_port_in_succession,_success#01 (0.00s)
```

```
--- PASS: TestDockerHostConfigPortBinding (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_ports_and_host_ports (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_ports_with_a_ideal_dynamicHostPortRange (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_ports_with_a_bad_dynamicHostPortRange (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_port_and_container_port_range_with_a_ideal_dynamicHostPortRange (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_port_and_container_port_range_with_a_bad_user-specified_dynamicHostPortRange (0.00s)
```

```
--- PASS: TestDockerHostConfigSCBridgeMode (0.00s)
    --- PASS: TestDockerHostConfigSCBridgeMode/with_default_dynamic_host_port_range (0.00s)
    --- PASS: TestDockerHostConfigSCBridgeMode/with_user-specified_dynamic_host_port_range (0.00s)
```

#### Manual testing
Re-ran test cases listed in [Upudate dockerPortMap() in task.go with dynamic host port range support - part 1](https://github.com/aws/amazon-ecs-agent/pull/3584), and test results are the same as expected.

New tests cover the changes: no

### Description for the changelog
N/A - Update comments and validate a host port or a host port range before returning from `GetHostPort()`/`GetHostPortRange()`.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
